### PR TITLE
Add timeout of 60s for exec-ed commands as a safeguard.

### DIFF
--- a/src/accessories/base.js
+++ b/src/accessories/base.js
@@ -40,7 +40,7 @@ const Accessory = class {
     if (self.homebridge.debug) {
       self.log(cmd)
     }
-    exec(cmd, (err, stdOut) => {
+    exec(cmd, { timeout: 60000 }, (err, stdOut) => {
       if (self.homebridge.debug) {
         self.log(stdOut)
       }


### PR DESCRIPTION
The python would sometimes get stuck on executing command like: `python /usr/local/lib/node_modules/homebridge-magichome-platform/src/flux_led.py 10.0.x.x -i`. 
This python process would stuck on near 100% cpu usage and the raspberry pi would have increased cpu temperature by 20-30 degrees.

This change should not have any negative side effects, as in normal use cases 60s should be enough for a command to execute.