### PR TITLE
Debounce setToCurrentColor to avoid random/unexpected final color

### DIFF
--- a/src/accessories/lightBulb.js
+++ b/src/accessories/lightBulb.js
@@ -6,6 +6,17 @@
 //  Copyright © 2018 sahilchaddha.com. All rights reserved.
 //
 
+function debounce (fn, wait) {
+  var timeout
+  return function () {
+    clearTimeout(timeout)
+    var args = arguments
+    timeout = setTimeout(function () {
+      fn.apply(this, args)
+    }, (wait || 1))
+  }
+}
+
 const convert = require('color-convert')
 const Accessory = require('./base')
 
@@ -147,7 +158,7 @@ const LightBulb = class extends Accessory {
 
   setHue(value, callback) {
     this.color.H = value
-    this.setToCurrentColor()
+    this.debouncedSetToCurrentColor()
     callback()
   }
 
@@ -157,7 +168,7 @@ const LightBulb = class extends Accessory {
 
   setBrightness(value, callback) {
     this.color.L = value
-    this.setToCurrentColor()
+    this.debouncedSetToCurrentColor()
     callback()
   }
 
@@ -167,7 +178,7 @@ const LightBulb = class extends Accessory {
 
   setSaturation(value, callback) {
     this.color.S = value
-    this.setToCurrentColor()
+    this.debouncedSetToCurrentColor()
     callback()
   }
 
@@ -187,6 +198,8 @@ const LightBulb = class extends Accessory {
     var base = '-x ' + this.setup + ' -c '
     this.sendCommand(base + converted[0] + ',' + converted[1] + ',' + converted[2])
   }
+
+  debouncedSetToCurrentColor = debounce(this.setToCurrentColor.bind(this), 250)
 }
 
 module.exports = LightBulb


### PR DESCRIPTION
## Issue
Should address:
* https://github.com/sahilchaddha/homebridge-magichome-platform/issues/25
* https://github.com/sahilchaddha/homebridge-magichome-platform/issues/22

## Overview
Add debouncedSetToCurrentColor on 250ms delay as the light bulb service receives possibly 3 set events in succession (hue, saturation, brightness). I found this would clobber the device with too many flux_led.py command invocations. Debouncing addresses this.

In my specific case, this fixed a scene that changed the light's brightness/color. I observed 3 `flux_led.py` commands with the same timestamp, and after looking through source code, realized it's probably 3-successive calls to `setToCurrentColor` caused by hue, saturation, brightness changes. We still want those 3 methods to mutate the `LightBulb#color` state. But want to debounce the actual `LightBulb#sendCommand`/`LightBulb#executeCommand` invocation as to not clobber the device.